### PR TITLE
[TC-5317] Allow commands to be explicitly named

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -184,8 +184,8 @@ CLI.prototype.scanCommands = function scanCommands(dir) {
 			var file = isDir ? path.join(dir, filename) : filename;
 			// we don't allow commands that start with _ or have spaces
 			if (fs.existsSync(file) && fs.statSync(file).isFile() && jsfile.test(filename) && (!isDir || !ignore.test(path.basename(file)))) {
-				// we don't allow commands that start with _ or have spaces
-				var name = filename.replace(jsfile, '').toLowerCase();
+				var command = require(file);
+				var name = command.name || filename.replace(jsfile, '').toLowerCase();
 				this.globalContext.command({
 					name: name,
 					path: file

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -19,6 +19,9 @@ var config = require('../config'),
 	__ = i18n.__,
 	__f = i18n.__f;
 
+/** Config command name. */
+exports.name = 'config';
+
 /** Config command description. */
 exports.desc = __('get and set config options');
 

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -19,6 +19,9 @@ var config = require('../config'),
 	__ = appc.i18n(__dirname).__,
 	fs = require('fs');
 
+/** Help command name. */
+exports.name = 'help';
+
 /** Help command description. */
 exports.desc = __('displays this help screen');
 

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -25,6 +25,9 @@ var appc = require('node-appc'),
 
 	typesList = ['all', 'os', 'nodejs', 'titanium', 'osx', 'jdk', 'haxm'];
 
+/** Info command name. */
+exports.name = 'info';
+
 /** Info command description. */
 exports.desc = __('display development environment information');
 

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -16,6 +16,9 @@
 var appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__;
 
+/** Login command name. */
+exports.name = 'login';
+
 /** Login command description. */
 exports.desc = __('logs into the Appcelerator network');
 

--- a/lib/commands/logout.js
+++ b/lib/commands/logout.js
@@ -16,6 +16,9 @@
 var appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__;
 
+/** Logout command name. */
+exports.name = 'logout';
+
 /** Logout command description. */
 exports.desc = __('logs out of the Appcelerator network');
 

--- a/lib/commands/module.js
+++ b/lib/commands/module.js
@@ -32,6 +32,9 @@ var appc = require('node-appc'),
 		tizen: 'Tizen'
 	};
 
+/** Module command name. */
+exports.name = 'module';
+
 /** Module command description. */
 exports.desc = __('displays installed Titanium modules');
 

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -22,6 +22,9 @@ var appc = require('node-appc'),
 	path = require('path'),
 	semver = require('semver');
 
+/** Plugin command name. */
+exports.name = 'plugin';
+
 /** Plugin command description. */
 exports.desc = __('displays installed Titanium CLI plugins');
 

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -38,6 +38,9 @@ var async = require('async'),
 /** SDK command title. */
 exports.title = __('SDK');
 
+/** SDK command name. */
+exports.name = 'sdk';
+
 /** SDK command description. */
 exports.desc = __('manages installed Titanium SDKs');
 

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -32,6 +32,9 @@ var appc = require('node-appc'),
 	__f = i18n.__f,
 	proxy = [];
 
+/** Setup command name. */
+exports.name = 'setup';
+
 /** Setup command description. */
 exports.desc = __('sets up the Titanium CLI');
 

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -18,6 +18,9 @@ var appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__,
 	async = require('async');
 
+/** Status command name. */
+exports.name = 'status';
+
 /** Status command description. */
 exports.desc = __('displays session information');
 


### PR DESCRIPTION
The problem is described in https://jira.appcelerator.org/browse/TC-5317

This PR introduces a new `name` attribute, which allows command files to tell the CLI which is the name of the command. It allows for more flexibility in command naming and organization.
