### PR TITLE
CLI-1034 Improve failture message when trying to build Titanium 6.0.0…

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -412,7 +412,8 @@ function run(locale) {
 			if (supported === false) {
 				logger.banner();
 				logger.error(__('Titanium SDK %s is incompatible with Node.js %s', sdk.name, process.version) + '\n');
-				logger.log(__('You will need to install Node.js %s in order to use this version of the Titanium SDK.', 'v' + appc.version.parseMax(sdk.packageJson.vendorDependencies.node)));
+				logger.log(__('You will need to install Node.js %s or higher in order to use this version of the Titanium SDK. However, we recommend to install maximum supported version Node.js %s.', 'v' + appc.version.parseMin(sdk.packageJson.vendorDependencies.node),'v' + appc.version.parseMax(sdk.packageJson.vendorDependencies.node)));
+				logger.log(__('You can download and install from here - https://nodejs.org/en/download/'));
 				logger.log();
 				process.exit(1);
 			} else if (supported === 'maybe' && !config.get('cli.hideNodejsWarning')) {


### PR DESCRIPTION
… with Node < 5

> [ERROR] Titanium SDK 6.0.0.v20160823163945 is incompatible with Node.js v0.10.7
> 
> You will need to install Node.js v4.0 or higher in order to use this version of the Titanium SDK. However, we recommend to install maximum supported version Node.js v5.
> 
> You can download and install from here - https://nodejs.org/en/download/
