### PR TITLE
feat: js config file support

### DIFF
--- a/hooks/config.js
+++ b/hooks/config.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { loadConfig } = require('../lib/config/index');
+const { normalizeConfig } = require('../lib/config/utils');
+
+exports.id = 'ti.config.js';
+exports.init = (logger, config, cli) => {
+	cli.on('build.config', {
+		post(data) {
+			const command = data.result[1];
+			const projectDirOption = command.options['project-dir'];
+			if (!projectDirOption) {
+				return;
+			}
+
+			const originalCallback = projectDirOption.callback;
+			projectDirOption.callback = function (projectDir) {
+				if (projectDir === '') {
+					// no option value was specified
+					// set project dir to current directory
+					projectDir = projectDirOption.default;
+				}
+				projectDir = path.resolve(projectDir);
+
+				const tiConfigPath = path.resolve(projectDir, 'ti.config.js');
+				if (!fs.existsSync(tiConfigPath) || fs.existsSync(path.join(projectDir, 'timodule.xml'))) {
+					return originalCallback.call(null, projectDir);
+				}
+
+				const tiConfig = loadConfig(projectDir);
+				const tiapp = normalizeConfig(tiConfig);
+				cli.argv.type = 'app';
+				cli.tiapp = tiapp;
+
+				// make sure the tiapp config is sane
+				const tiModulePath = require.resolve('node-titanium-sdk', { paths: [ cli.sdk.path ] });
+				const ti = require(tiModulePath);
+				ti.validateTiappXml(logger, config, tiapp);
+
+				cli.scanHooks(path.join(projectDir, 'hooks'));
+
+				return projectDir;
+			};
+
+			const originalValidate = projectDirOption.validate;
+			projectDirOption.validate = function (projectDir, callback) {
+				projectDir = path.resolve(projectDir);
+				const configPath = path.join(projectDir, 'ti.config.js');
+				if (fs.existsSync(configPath)) {
+					return callback(null, projectDir);
+				}
+
+				originalValidate(projectDir, callback);
+			};
+		},
+		// prio of 900 to run before tisdk3fixes.js
+		priority: 900
+	});
+};

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = () => ({
+	properties: {},
+	webpack: {
+		transpileDependencies: []
+	},
+	modules: [],
+	plugins: []
+});

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const joi = require('@hapi/joi');
+const fs = require('fs-extra');
+const defaultsDeep = require('lodash.defaultsdeep');
+const path = require('path');
+
+const defaults = require('./defaults');
+const schema = require('./schema');
+const { clearRequireCache } = require('./utils');
+
+function loadConfig(projectPath, force = false) {
+	const tiConfigPath = path.resolve(projectPath, 'ti.config.js');
+	if (!fs.existsSync(tiConfigPath)) {
+		throw new Error(`Could not find Titanium config at ${tiConfigPath}`);
+	}
+	if (force) {
+		clearRequireCache(tiConfigPath);
+	}
+	const config = require(tiConfigPath);
+	const pkgPath = path.join(projectPath, 'package.json');
+	if (fs.existsSync(pkgPath)) {
+		const pkg = fs.readJsonSync(pkgPath);
+		config.name = config.name || pkg.name;
+		config.description = config.description || pkg.description;
+		config.version = config.version || pkg.version;
+	}
+	validateConfig(config, schema);
+	return defaultsDeep(config, defaults());
+}
+
+function validateConfig(obj) {
+	joi.assert(obj, schema);
+}
+
+module.exports = {
+	loadConfig,
+	validateConfig
+};

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const joi = require('@hapi/joi');
+
+const schema = joi.object({
+	// General app info
+	id: joi.string()
+		.required(),
+	name: joi.string()
+		.required(),
+	description: joi.string(),
+	version: joi.string(),
+	guid: joi.string()
+		.required()
+		.guid(),
+	publisher: joi.string(),
+	url: joi.string(),
+	copyright: joi.string(),
+
+	// App configuration
+	icon: joi.string(),
+	fullscreen: joi.boolean(),
+	navbarHidden: joi.boolean(),
+	statusbarHidden: joi.boolean(),
+	analytics: joi.boolean(),
+	properties: joi.object(),
+	android: joi.object({
+		manifest: joi.forbidden(),
+		abi: joi.string(),
+		// FIXME. How to handle this? Automatically read in a file similar to the manifest
+		// under platform/android/activities.xml ?
+		activities: joi.forbidden(),
+		services: joi.forbidden()
+	}),
+	ios: joi.object({
+		teamId: joi.string()
+			.when('extensions', {
+				is: joi.exist(),
+				then: joi.required()
+			}),
+		entitlements: joi.forbidden(),
+		extensions: joi.array().items(joi.object({
+			projectPath: joi.string(),
+			targets: joi.array().items(joi.object({
+				name: joi.string().required(),
+				provisioningProfiles: joi.object({
+					devices: joi.string(),
+					distAppstore: joi.string(),
+					disAdhoc: joi.string()
+				})
+			}))
+		})),
+		plist: joi.forbidden(),
+		enableLaunchScreenStoryboard: joi.boolean(),
+		useAppThinning: joi.boolean(),
+		useAutolayout: joi.boolean(),
+		useJscoreFramework: joi.boolean(),
+		minIosVersion: joi.string(),
+		minSdkVersion: joi.string(),
+		logServerPort: joi.number()
+	}).unknown(),
+	windows: joi.object({
+		id: joi.string(),
+		manifest: joi.forbidden()
+	}),
+	sdkVersion: joi.string()
+		.required(),
+	deploymentTargets: joi.array().valid('android', 'ipad', 'iphone'),
+
+	// Webpack
+	webpack: joi.object({
+		type: joi.string().valid('angular', 'classic', 'vue'),
+		transpileDependencies: joi.array().items(
+			joi.string(),
+			joi.object().instance(RegExp)
+		)
+	}),
+
+	// Modules and Plugins
+	modules: joi.array().items(
+		joi.string(),
+		joi.array().ordered(
+			joi.string(),
+			joi.object({
+				version: joi.string().required(),
+				platform: joi.string().valid('android', 'iphone', 'commonjs'),
+				deployType: joi.string().valid('development', 'test', 'production')
+			})
+		)
+	),
+	plugins: joi.array().items(
+		joi.string(),
+		joi.array().ordered(
+			joi.string(),
+			joi.object({
+				version: joi.string().required()
+			})
+		)
+	)
+}).unknown();
+
+module.exports = schema;

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -1,0 +1,75 @@
+'use strict';
+
+function normalizeConfig(jsConfig) {
+	const config = normalizePropertyNames(jsConfig);
+
+	config.modules = config.modules.filter(m => m).map(m => normalizeDependency(m));
+	config.plugins = config.plugins.filter(p => p).map(p => normalizeDependency(p, 'plugin'));
+
+	return config;
+}
+
+function normalizePropertyNames(obj) {
+	if (Array.isArray(obj)) {
+		return obj.map(v => normalizePropertyNames(v));
+	} else if (typeof obj === 'object' && obj !== null) {
+		const result = {};
+		Object.getOwnPropertyNames(obj).forEach(propertyName => {
+			let value = obj[propertyName];
+			value = normalizePropertyNames(value);
+			result[propertyName] = value;
+			const kebabCasePropertyName = camelCaseToKebabCase(propertyName);
+			if (kebabCasePropertyName !== propertyName) {
+				Object.defineProperty(result, kebabCasePropertyName, {
+					get() {
+						return result[propertyName];
+					},
+					set(value) {
+						result[propertyName] = value;
+					},
+					enumerable: true
+				});
+			}
+		});
+		return result;
+	} else {
+		return obj;
+	}
+}
+
+function camelCaseToKebabCase(value) {
+	return value.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase();
+}
+
+function normalizeDependency(dep, type = 'module') {
+	if (Array.isArray(dep)) {
+		const moduleId = dep[0];
+		const moduleOptions = dep[1] || {};
+		return Object.assign({ id: moduleId }, moduleOptions);
+	} else if (typeof dep === 'string') {
+		return { id: dep };
+	} else if (typeof dep === 'object') {
+		return dep;
+	} else {
+		throw new TypeError(`Invalid ${type} configuration. Expected a type of "array", "string" or "object". Received ${typeof dep}`);
+	}
+}
+
+function clearRequireCache (id, map = new Map()) {
+	const module = require.cache[id];
+	if (module) {
+		map.set(id, true);
+		// Clear children modules
+		module.children.forEach(child => {
+			if (!map.get(child.id)) {
+				clearRequireCache(child.id, map);
+			}
+		});
+		delete require.cache[id];
+	}
+}
+
+module.exports = {
+	normalizeConfig,
+	clearRequireCache
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,46 @@
 				}
 			}
 		},
+		"@hapi/address": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+		},
+		"@hapi/formula": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+			"integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+		},
+		"@hapi/hoek": {
+			"version": "8.2.5",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.5.tgz",
+			"integrity": "sha512-rmGFzok1zR3xZKd5m3ihWdqafXFxvPHoQ/78+AG5URKbEbJiwBBfRgzbu+07W5f3+07JRshw6QqGbVmCp8ntig=="
+		},
+		"@hapi/joi": {
+			"version": "16.1.4",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.4.tgz",
+			"integrity": "sha512-m7ctezhxjob+dSpXnCNlgAj6rrEpdSsaWu3GWL3g1AybQCU36mlAo9IwGFJwIxD+oHgdO6mYyviYlaejX+qN6g==",
+			"requires": {
+				"@hapi/address": "^2.1.2",
+				"@hapi/formula": "^1.2.0",
+				"@hapi/hoek": "^8.2.4",
+				"@hapi/pinpoint": "^1.0.2",
+				"@hapi/topo": "^3.1.3"
+			}
+		},
+		"@hapi/pinpoint": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+			"integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+		},
+		"@hapi/topo": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
+			"integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
+			"requires": {
+				"@hapi/hoek": "8.x.x"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",
@@ -3834,6 +3874,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
+		},
+		"lodash.defaultsdeep": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+			"integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
 		},
 		"lodash.find": {
 			"version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
 	},
 	"preferGlobal": true,
 	"dependencies": {
+		"@hapi/joi": "^16.1.4",
 		"adm-zip": "0.4.13",
 		"async": "^2.6.3",
 		"colors": "1.3.3",
 		"fields": "0.1.24",
 		"humanize": "0.0.9",
+		"lodash.defaultsdeep": "^4.6.1",
 		"moment": "^2.24.0",
 		"node-appc": "^0.2.49",
 		"request": "2.88.0",
@@ -111,7 +113,7 @@
 		]
 	},
 	"engines": {
-		"node": ">=4.0"
+		"node": ">=8.0"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
This is a prototype for JavaScript based configuration of Titanium projects. It hooks into `build` commands and checks whether a `ti.config.js` is present. If found, it will use that instead of the good old `tiapp.xml`.

**Current features:**
- Loading and normalization of the JS config to match `tiapp.xml` format. All properties can be specified in camel-case. They will be converted to kebab-case for backwards compatibility.
- Fallback to `package.json` for `name`, `description` and `version`.
- Transparent injection into the CLI via a hook. No changes required to any code that relies on `cli.tiapp`, e.g. our builders.
- Additional schema validation using [@hapi/joi](https://github.com/hapijs/joi#readme).
- Force bypassing of require cache. Required when used inside the daemon to reload config file from disk.

**Example config**
```js
module.exports = {
  name: 'global-test-classic',
  id: 'com.appc.pushnotifications',
  guid: 'cd064de9-d38f-4ae2-c888-b3189586ea5a',
  icon: 'appicon.png',
  fullscreen: false,
  properties: {
    'ti.ui.defaultunit': 'dp',
  },
  ios: {
    enableLaunchScreenStoryboard: true,
    useAppThinning: true,
    minIosVersion: '12.0'
  },
  modules: [
    'ti.map',
    ['facebook', { version: '6.0.0' }]
  ]
  sdkVersion: '8.2.0'
};

```

**To-Do:**
- Find a suitable replacement for inlined XML commonly used in `tiapp.xml`. For `ios.plist` and `android.manifest` we already support loading files from the project directory. For other XML values like `ios.entitlements` or `android.activities` we could use a similar approach and load matching files from `platform` folder, e.g. `platform/ios/entitlements.plist` or `platform/android/activities.xml`.
- Verify against a bigger project. There are probably some config normalizations/conversions missing. I'll need to test against a bigger real-world project.
- The code under [lib/config](lib/config) needs go into a separate module.