### PR TITLE
[TIMOB-27764] Add support for loading global CLI plugins from local directory

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -63,6 +63,9 @@ function CLI(params) {
 	// call the Hook constructor
 	Hook.call(this);
 
+	// scan for local global hooks
+	this.scanHooks(path.join(process.cwd(), 'plugins'), /titanium-global-plugin\.js$/);
+
 	// find all hooks in the user's config paths
 	var paths = this.config.paths.hooks;
 	(Array.isArray(paths) ? paths : [ paths ]).forEach(function (p) {

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -50,7 +50,7 @@ function findInDir (dir, include = /\.js$/, exclude = /^[._]/, fileList = []) {
 	const files = fs.readdirSync(dir);
 	for (const file of files) {
 		const filePath = path.join(dir, file);
-		const fileStat = fs.lstatSync(filePath);
+		const fileStat = fs.statSync(filePath);
 
 		if (fileStat.isDirectory()) {
 			findInDir(filePath, include, exclude, fileList);

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -48,7 +48,7 @@ function Hook() {
 
 function findInDir (dir, include = /\.js$/, exclude = /^[._]/, fileList = []) {
 	const files = fs.readdirSync(dir);
-	files.forEach((file) => {
+	for (const file of files) {
 		const filePath = path.join(dir, file);
 		const fileStat = fs.lstatSync(filePath);
 
@@ -57,7 +57,7 @@ function findInDir (dir, include = /\.js$/, exclude = /^[._]/, fileList = []) {
 		} else if (include.test(filePath) && !exclude.test(filePath)) {
 			fileList.push(filePath);
 		}
-	});
+	}
 
 	return fileList;
 }

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -46,6 +46,22 @@ function Hook() {
 	};
 }
 
+function findInDir (dir, include = /\.js$/, exclude = /^[._]/, fileList = []) {
+	const files = fs.readdirSync(dir);
+	files.forEach((file) => {
+		const filePath = path.join(dir, file);
+		const fileStat = fs.lstatSync(filePath);
+
+		if (fileStat.isDirectory()) {
+			findInDir(filePath, include, exclude, fileList);
+		} else if (include.test(filePath) && !exclude.test(filePath)) {
+			fileList.push(filePath);
+		}
+	});
+
+	return fileList;
+}
+
 /**
  * @constant
  * @type {Number}
@@ -57,40 +73,37 @@ Hook.HOOK_PRIORITY_DEFAULT = 1000;
  * Scans the specified path for hooks. Each hook is identified by a JavaScript
  * file.
  * @param {String} dir - A directory or JavaScript file to be scanned.
+ * @param {RegExp} include - Regular expression to match for included filenames.
+ * @param {RegExp} exclude - Regular expression to match for excluded filenames.
  */
-Hook.prototype.scanHooks = function scanHooks(dir) {
+Hook.prototype.scanHooks = function scanHooks(dir, include, exclude) {
 	if (!this.hooks.scannedPaths[dir] && fs.existsSync(dir)) {
-		var jsfile = /\.js$/,
-			ignore = /^[._]/,
-			isDir = fs.statSync(dir).isDirectory();
+		const fileList = findInDir(dir, include, exclude);
 
-		(isDir ? fs.readdirSync(dir) : [ dir ]).forEach(function (filename) {
-			var file = isDir ? path.join(dir, filename) : filename;
-			if (fs.existsSync(file) && fs.statSync(file).isFile() && jsfile.test(filename) && (!isDir || !ignore.test(path.basename(file)))) {
-				try {
-					vm.runInThisContext('(function (exports, require, module, __filename, __dirname) { ' + fs.readFileSync(file).toString() + '\n});', file, 0, false);
-					var mod = require(file);
-					if (mod.id) {
-						Array.isArray(this.hooks.ids[mod.id]) || (this.hooks.ids[mod.id] = []);
-						this.hooks.ids[mod.id].push({
-							file: file,
-							version: mod.version || null
-						});
-						// don't load duplicate ids
-						if (this.hooks.ids[mod.id].length > 1) {
-							return;
-						}
+		fileList.forEach(function (file) {
+			try {
+				vm.runInThisContext('(function (exports, require, module, __filename, __dirname) { ' + fs.readFileSync(file).toString() + '\n});', file, 0, false);
+				var mod = require(file); // eslint-disable-line security/detect-non-literal-require
+				if (mod.id) {
+					Array.isArray(this.hooks.ids[mod.id]) || (this.hooks.ids[mod.id] = []);
+					this.hooks.ids[mod.id].push({
+						file: file,
+						version: mod.version || null
+					});
+					// don't load duplicate ids
+					if (this.hooks.ids[mod.id].length > 1) {
+						return;
 					}
-					if (!this.version || !mod.cliVersion || semver.satisfies(appc.version.format(this.version, 0, 3, true), mod.cliVersion)) {
-						mod.init && mod.init(this.logger, this.config, this, appc);
-						this.hooks.loadedFilenames.push(file);
-					} else {
-						this.hooks.incompatibleFilenames.push(file);
-					}
-				} catch (ex) {
-					this.hooks.erroredFilenames.push(file);
-					this.hooks.errors[file] = ex;
 				}
+				if (!this.version || !mod.cliVersion || semver.satisfies(appc.version.format(this.version, 0, 3, true), mod.cliVersion)) {
+					mod.init && mod.init(this.logger, this.config, this, appc);
+					this.hooks.loadedFilenames.push(file);
+				} else {
+					this.hooks.incompatibleFilenames.push(file);
+				}
+			} catch (ex) {
+				this.hooks.erroredFilenames.push(file);
+				this.hooks.errors[file] = ex;
 			}
 		}, this);
 		this.hooks.scannedPaths[dir] = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2569,6 +2569,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
 			"integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -4397,7 +4398,8 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
 		},
 		"nested-error-stacks": {
 			"version": "2.1.0",
@@ -4591,7 +4593,7 @@
 				},
 				"find-up": {
 					"version": "3.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
@@ -4620,7 +4622,7 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
@@ -4630,7 +4632,7 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
@@ -4676,7 +4678,7 @@
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		]
 	},
 	"engines": {
-		"node": ">=4.0"
+		"node": ">=8.0"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
This would allow a developer to put a global plugin in the local plugins directory and have it use this.

The global plugin would need to be named "titanium-global-plugin.js"

Currently the first batch of hooks used by the CLI cannot be used by local plugins and can only be used by global plugins. Doing this would remove one of the last obstacles for using global plugins as it could then be used on a per-project basis, if desired.