### PR TITLE
TiDev Banner Copy Updates

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -96,7 +96,10 @@ logger.banner = function () {
 	var info = appc.pkginfo.package(module, 'version', 'about');
 	if (bannerEnabled) {
 		logger.log(info.about.name.cyan.bold + ', CLI version ' + info.version + (logger.activeSdk ? ', Titanium SDK version ' + logger.activeSdk : '') + '\n' + info.about.copyright);
-		logger.log('\n' + __('Please report bugs to %s', 'https://github.com/appcelerator/titanium_mobile/issues'.cyan) + '\n');
+		logger.log('\n' + __('- 🪳  Please report bugs to %s', 'https://github.com/tidev/titanium_mobile/issues'.cyan));
+		logger.log(__('- 🪄  Remember! Titanium is a community supported open-source project and relies on donations for on-going development.'));
+		logger.log(__('- ❤️  Support the project here %s', 'https://liberapay.com/tidev'.cyan));
+		logger.log(__('- 🤝 Join the TiDev Slack community here: %s \n', 'https://tislack.org'.cyan));
 		logger.emit('cli:logger-banner');
 		bannerWasRendered = true;
 	}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -96,10 +96,10 @@ logger.banner = function () {
 	var info = appc.pkginfo.package(module, 'version', 'about');
 	if (bannerEnabled) {
 		logger.log(info.about.name.cyan.bold + ', CLI version ' + info.version + (logger.activeSdk ? ', Titanium SDK version ' + logger.activeSdk : '') + '\n' + info.about.copyright);
-		logger.log('\n' + __('- 🪳  Please report bugs to %s', 'https://github.com/tidev/titanium_mobile/issues'.cyan));
-		logger.log(__('- 🪄  Remember! Titanium is a community supported open-source project and relies on donations for on-going development.'));
-		logger.log(__('- ❤️  Support the project here %s', 'https://liberapay.com/tidev'.cyan));
-		logger.log(__('- 🤝 Join the TiDev Slack community here: %s \n', 'https://tislack.org'.cyan));
+		logger.log('\n' + __('- Please report bugs here: %s', 'https://github.com/tidev/titanium_mobile/issues'.cyan));
+		logger.log(__('- Remember! Titanium is a community supported open-source project and relies on donations for on-going development.'));
+		logger.log(__('- Support the project here: %s', 'https://liberapay.com/tidev'.cyan));
+		logger.log(__('- Join the TiDev Slack community here: %s \n', 'https://tislack.org'.cyan));
 		logger.emit('cli:logger-banner');
 		bannerWasRendered = true;
 	}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
 	"about": {
 		"name": "Titanium Command-Line Interface",
 		"author": "Appcelerator",
-		"copyright": "Copyright (c) 2012-2020, Appcelerator, Inc.  All Rights Reserved.",
+		"copyright": "Copyright (c) 2012-2022, TiDev, Inc. All Rights Reserved.",
 		"id": "com.appcelerator.titanium.cli"
 	},
 	"name": "titanium",
-	"description": "Appcelerator Titanium Command line",
+	"description": "TiDev Titanium Command line",
 	"keywords": [
 		"appcelerator",
 		"titanium",


### PR DESCRIPTION
This PR updates the Titanium banner that displays to:

1. Display TiDev as the project copyright maintainer.
2. Promote the Titanium Slack community.
3. Promote the TiDev Liberapay link.

It displays like this on iTerm+ZSH like this:

<img width="942" alt="Screen Shot 2022-03-23 at 6 50 31 PM" src="https://user-images.githubusercontent.com/1421842/159814960-1d99dc1a-c653-4397-a1bd-d475137d348f.png">

