### PR TITLE
Don't add dupe options

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -205,11 +205,13 @@ export class CLI {
 		if (Array.isArray(cmd?.options)) {
 			const argv = this.argv;
 			const cargv = cmd.opts();
+			this.debugLogger.trace(`Copying ${cmd.options.length} options...`);
 			for (const o of cmd.options) {
 				let name = o.name();
 				if (o.negate) {
 					name = name.replace(/^no-/, '');
 				}
+				this.debugLogger.trace(`  Setting ${name} = ${cargv[o.attributeName()]}`);
 				argv[name] = cargv[o.attributeName()];
 			}
 		}
@@ -733,6 +735,7 @@ export class CLI {
 		// SDK, load the SDK hooks, and load the actual command module
 		program.hook('preSubcommand', async (_, cmd) => {
 			const cmdName = cmd.name();
+			this.debugLogger.trace(`Initializing command: ${cmdName}`);
 			this.command = cmd;
 
 			this.applyArgv(program);
@@ -904,7 +907,7 @@ export class CLI {
 	 * @access private
 	 */
 	async loadSDK({ cmdName, cwd }) {
-		this.debugLogger.trace(`Loading SDK ('${cmdName}')`);
+		this.debugLogger.trace('Loading SDK...');
 
 		// this is a hack... if we know this is the "create" command and there
 		// are no options set, then assume we're prompting for everything
@@ -924,6 +927,7 @@ export class CLI {
 		} = await initSDK({
 			config: this.config,
 			cwd,
+			debugLogger: this.debugLogger,
 			logger: this.logger,
 			promptingEnabled: this.promptingEnabled,
 			selectedSdk: this.argv.sdk,
@@ -960,7 +964,7 @@ export class CLI {
 
 		// if we're running a sdk command, then scan the sdk for hooks
 		if (sdkCommands[cmdName]) {
-			this.debugLogger.trace(`Loading SDK hooks ('${cmdName}')`);
+			this.debugLogger.trace('Loading SDK hooks...');
 			await this.scanHooks(expand(this.sdk.path, 'cli', 'hooks'));
 		}
 	}

--- a/src/util/apply-command-config.js
+++ b/src/util/apply-command-config.js
@@ -51,6 +51,11 @@ export function applyCommandConfig(cli, cmdName, cmd, conf) {
 				opt.default(meta.default);
 			}
 
+			if (optionExists(cmd, name)) {
+				cli.debugLogger.trace(`Option "${name}" already exists, skipping`);
+				continue;
+			}
+
 			cli.debugLogger.trace(`Adding "${cmdName}" option: ${meta.abbr ? `-${meta.abbr}, ` : ''}${long} [value]`);
 			cmd.addOption(opt);
 
@@ -147,4 +152,15 @@ export function applyCommandConfig(cli, cmdName, cmd, conf) {
 			});
 		}
 	}
+}
+
+function optionExists(ctx, name) {
+	const exists = ctx.options.find(o => o.name() === name);
+	if (exists) {
+		return true;
+	}
+	if (ctx.parent) {
+		return optionExists(ctx.parent, name);
+	}
+	return false;
 }

--- a/src/util/tisdk.js
+++ b/src/util/tisdk.js
@@ -133,14 +133,17 @@ function getSDKType(name) {
 
 const sortTypes = ['unsupported', 'beta', 'rc', 'ga'];
 
-export async function initSDK({ config, cwd, logger, promptingEnabled, selectedSdk, showSDKPrompt }) {
+export async function initSDK({ config, cwd, debugLogger, logger, promptingEnabled, selectedSdk, showSDKPrompt }) {
 	let sdkVersion;
 
 	// try to read the tiapp.xml
 	let tiapp = new Tiapp();
 	try {
-		await tiapp.load(join(cwd, 'tiapp.xml'));
+		const tiappFile = join(cwd, 'tiapp.xml');
+		await tiapp.load(tiappFile);
+		debugLogger.trace(`Loaded ${tiappFile}`);
 		sdkVersion = await tiapp.select1('//sdk-version', 'latest');
+		debugLogger.trace(`<sdk-version> is ${sdkVersion ? `set to ${sdkVersion}` : 'undefined'}`);
 	} catch {
 		// might not be a project dir or bad tiapp.xml
 	}


### PR DESCRIPTION
`--project-dir` is a global option so that the `tiapp.xml` can be loaded, however the `build` command has a `--project-dir` option and it overwrites the global one. Not only does it overwrite the option itself, it overwrites the parsed value from the global option with the default value.