### PR TITLE
fix: properly handle confirm sdk uninstall prompt response, fixes #645

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.1.0
+-------------------
+ * fix: `ti sdk rm <ver>` treats confirm prompt as false
+
 7.0.0 (5/10/2024)
 -------------------
  * Require Node.js 18 or newer

--- a/src/commands/sdk.js
+++ b/src/commands/sdk.js
@@ -824,7 +824,7 @@ SdkSubcommands.uninstall = {
 			}
 			logger.log();
 
-			const { confirm } = await prompt({
+			const confirm = await prompt({
 				type: 'toggle',
 				name: 'confirm',
 				message: 'Proceed?',


### PR DESCRIPTION
When you run `ti sdk rm 12.3.0.GA`, it prompts a "yes" or "no" confirmation, however selecting either results in a falsey value and the uninstall exits.