### PR TITLE
fix: surface sdk install errors, fixes #648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.1.0
+-------------------
+ * fix: Surface sdk install errors
+
 7.0.0 (5/10/2024)
 -------------------
  * Require Node.js 18 or newer

--- a/src/util/tisdk.js
+++ b/src/util/tisdk.js
@@ -271,12 +271,12 @@ export async function getReleases(unstable) {
 		}).then(async res => ({ type: 'ga', releases: await res.body.json() }))
 	];
 
-	const results = await Promise.allSettled(fetches);
+	const results = await Promise.all(fetches);
 
 	return results
-		.flatMap(r => {
-			return r.status === 'fulfilled' && r.value ? r.value.releases.map(rel => {
-				rel.type = r.value.type;
+		.flatMap(value => {
+			return value ? value.releases.map(rel => {
+				rel.type = value.type;
 				return rel;
 			}) : [];
 		})


### PR DESCRIPTION
If the CLI fails to download the list of releases, print an error message.

To test, using Node 16 run `ti sdk ls -ru`.

Before:
```
Releases:
   No releases found
```

After:
```
Releases:
   ReferenceError: ReadableStream is not defined
```