### PR TITLE
fix: assert required node.js version, fixes #647

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.1.0
+-------------------
+ * fix: Assert required Node.js version
+
 7.0.0 (5/10/2024)
 -------------------
  * Require Node.js 18 or newer

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ import { TiError } from './util/tierror.js';
 import { prompt } from './util/prompt.js';
 import { applyCommandConfig } from './util/apply-command-config.js';
 import { TiHelp } from './util/tihelp.js';
+import semver from 'semver';
 
 const { blue, bold, cyan, gray, green, magenta, red, yellow } = chalk;
 
@@ -167,11 +168,12 @@ export class CLI {
 
 	constructor() {
 		const pkgJsonFile = join(dirname(fileURLToPath(import.meta.url)), '../package.json');
-		const { version } = fs.readJsonSync(pkgJsonFile);
+		const { engines, version } = fs.readJsonSync(pkgJsonFile);
 
 		this.name = 'Titanium Command-Line Interface';
 		this.copyright = 'Copyright TiDev, Inc. 4/7/2022-Present. All Rights Reserved.';
 		this.version = version;
+		this.nodeVersion = engines?.node;
 		this.logger.setBanner({
 			name: this.name,
 			copyright: this.copyright,
@@ -510,6 +512,10 @@ export class CLI {
 	 * @access public
 	 */
 	async go() {
+		if (this.nodeVersion && !semver.satisfies(process.version, this.nodeVersion)) {
+			throw new TiError(`Node.js version ${this.nodeVersion} required, current version is ${process.version}`);
+		}
+
 		Command.prototype.createHelp = () => {
 			return Object.assign(new TiHelp(this), this.command.configureHelp());
 		};


### PR DESCRIPTION
If the Node.js version is too old, show an error and exit.

Node 16:
```
> ti
Titanium Command-Line Interface v7.0.0
Copyright TiDev, Inc. 4/7/2022-Present. All Rights Reserved.

Want to help? https://tidev.io/donate or https://tidev.io/contribute

Error: Node.js version >=18 required, current version is v16.18.1
```