### PR TITLE
fix: Clear undefined command args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * fix: Surface sdk install errors
  * fix: `ti sdk rm <ver>` treats confirm prompt as false
  * fix: Assert required Node.js version
+ * fix: Clear out undefined command args which fixes `ti project`
 
 7.0.0 (5/10/2024)
 -------------------

--- a/src/cli.js
+++ b/src/cli.js
@@ -416,6 +416,11 @@ export class CLI {
 		const cmd = args.pop();
 		args.pop(); // discard argv
 
+		// remove any trailing undefined args
+		while (args.length && args[args.length - 1] === undefined) {
+			args.pop();
+		}
+
 		this.argv._ = args;
 		this.applyArgv(cmd);
 

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -109,8 +109,8 @@ export function validate(_logger, _config, cli) {
  */
 export async function run(logger, config, cli) {
 	const { argv } = cli;
-	const key = argv._.length > 0 && argv._.shift();
-	const value = argv._.length > 0 && argv._[0];
+	const key = argv._.length > 0 ? argv._.shift() : undefined;
+	const value = argv._.length > 0 ? argv._[0] : undefined;
 	const results = {};
 	const asJson = argv.json || argv.output === 'json';
 


### PR DESCRIPTION
Due to the way Commander.js works, if you have a command with arguments (e.g. `ti project`), Commander.js passes in `undefined` for any unset arguments.

For example, `ti project <key> <value>` would pass in `[undefined, undefined]` when running `ti project` (no key/value). The way `ti project` works is it checks the length of the args and it sees a length of 2, but the values are `undefined` causing an error.

This PR will pop `undefined` args off the args array until it hits a non-undefined value or the array is empty.

To test, simply run `ti project` with any SDK in any app using CLI v7.