### PR TITLE
fix: Fixed 'ti sdk install' silent fail when copying new modules to dest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * fix: `ti sdk rm <ver>` treats confirm prompt as false
  * fix: Assert required Node.js version
  * fix: Clear out undefined command args which fixes `ti project`
+ * fix: Fixed `ti sdk install` bug when installing new module files
 
 7.0.0 (5/10/2024)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
  * fix: `ti sdk rm <ver>` treats confirm prompt as false
  * fix: Assert required Node.js version
  * fix: Clear out undefined command args which fixes `ti project`
- * fix: `ti sdk install` silently fails when installing new modules
+ * fix: `ti sdk install` no longer silently fails when installing new modules
+ * fix: When reinstalling an SDK, choosing "Overwrite" will force modules to
+   also be reinstalled
+ * fix: Properly handle result from `ti sdk install` overwrite prompt,
+   `ti sdk uninstall` version prompt, and `ti setup user` name prompt
 
 7.0.0 (5/10/2024)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * fix: `ti sdk rm <ver>` treats confirm prompt as false
  * fix: Assert required Node.js version
  * fix: Clear out undefined command args which fixes `ti project`
- * fix: Fixed `ti sdk install` bug when installing new module files
+ * fix: `ti sdk install` silently fails when installing new modules
 
 7.0.0 (5/10/2024)
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "titanium",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",

--- a/src/commands/sdk.js
+++ b/src/commands/sdk.js
@@ -404,39 +404,37 @@ SdkSubcommands.install = {
 
 		const modules = [];
 		src = join(tempDir, 'modules');
-		try {
-			if (fs.statSync(src).isDirectory()) {
-				const modulesDest = join(titaniumDir, 'modules');
+		if (fs.statSync(src).isDirectory()) {
+			const modulesDest = join(titaniumDir, 'modules');
 
-				for (const platform of fs.readdirSync(src)) {
-					const srcPlatformDir = join(src, platform);
-					if (!fs.statSync(srcPlatformDir).isDirectory()) {
+			for (const platform of fs.readdirSync(src)) {
+				const srcPlatformDir = join(src, platform);
+				if (!fs.statSync(srcPlatformDir).isDirectory()) {
+					continue;
+				}
+
+				for (const moduleName of fs.readdirSync(srcPlatformDir)) {
+					const srcModuleDir = join(srcPlatformDir, moduleName);
+					if (!fs.statSync(srcModuleDir).isDirectory()) {
 						continue;
 					}
 
-					for (const moduleName of fs.readdirSync(srcPlatformDir)) {
-						const srcModuleDir = join(srcPlatformDir, moduleName);
-						if (!fs.statSync(srcModuleDir).isDirectory()) {
+					for (const ver of fs.readdirSync(srcModuleDir)) {
+						const srcVersionDir = join(srcModuleDir, ver);
+						if (!fs.statSync(srcVersionDir).isDirectory()) {
 							continue;
 						}
 
-						for (const ver of fs.readdirSync(srcModuleDir)) {
-							const srcVersionDir = join(srcModuleDir, ver);
-							if (!fs.statSync(srcVersionDir).isDirectory()) {
-								continue;
-							}
-
-							const destDir = join(modulesDest, platform, moduleName, ver);
-							if (!cli.argv.force || fs.statSync(destDir).isDirectory()) {
-								continue;
-							}
-
-							modules.push({ src: srcVersionDir, dest: destDir });
+						const destDir = join(modulesDest, platform, moduleName, ver);
+						if (!cli.argv.force || fs.existsSync(destDir)) {
+							continue;
 						}
+
+						modules.push({ src: srcVersionDir, dest: destDir });
 					}
 				}
 			}
-		} catch {}
+		}
 
 		if (modules.length) {
 			for (const { src, dest } of modules) {

--- a/src/commands/sdk.js
+++ b/src/commands/sdk.js
@@ -426,7 +426,7 @@ SdkSubcommands.install = {
 						}
 
 						const destDir = join(modulesDest, platform, moduleName, ver);
-						if (!cli.argv.force || fs.existsSync(destDir)) {
+						if (!cli.argv.force && fs.existsSync(destDir)) {
 							continue;
 						}
 

--- a/src/commands/sdk.js
+++ b/src/commands/sdk.js
@@ -646,8 +646,8 @@ async function extractSDK({ debugLogger, file, force, logger, noPrompt, osName, 
 					subject
 				});
 
-				forceModules = result.forceModules ?? force;
-				renameTo = result.renameTo;
+				forceModules = result?.forceModules ?? force;
+				renameTo = result?.renameTo;
 
 				logger.log('Extracting SDK...');
 				if (showProgress && !bar) {

--- a/src/util/setup-screens.js
+++ b/src/util/setup-screens.js
@@ -521,7 +521,7 @@ export class SetupScreens {
 	async userScreen() {
 		this.logger.log(screenTitle('User'));
 
-		const { name } = await prompt({
+		const name = await prompt({
 			type: 'text',
 			message: 'What do you want as your "author" name?',
 			initial: this.config.get('user.name', ''),


### PR DESCRIPTION
The part of `ti sdk install` that copies the module files was wrapped in a try/catch, but didn't surface the error.

The try/catch was basically a lazy catch when `fs.statSync(destDir).isDirectory()` throws for `destDir` not existing (e.g. new module found). Getting rid of the try/catch shows the error that `destDir` doesn't exist, which was expected, however throwing was breaking out of all the nested loops when recursively copying the module files to the dest. The solution is to remove the try/catch and use `fs.existsSync()`.

This PR also resolves 2 other related issues.

1. When installing an SDK that is already installed, it prompts the user if they want to overwrite the existing install, but it wasn't also overwriting the modules.
2. There are 3 prompts that were incorrectly handling the return value from a prompt just like what happened in #649:
    1. SDK install overwrite prompt
    2. SDK uninstall version selection prompt
    3. `ti setup user` author name prompt