### PR TITLE
fix: Rename platform config `iphone` to `ios`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+7.1.1
+-------------------
+ * fix: Rename platform config `iphone` to `ios` to align with
+   `ti.targetPlatforms`
+
 7.1.0 (5/25/2024)
 -------------------
  * feat: Support async hook `init()` functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "titanium",
-	"version": "7.1.0",
+	"version": "7.1.1",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",

--- a/src/cli.js
+++ b/src/cli.js
@@ -681,6 +681,7 @@ export class CLI {
 		const platformConf = this.command.conf.platforms[this.argv.platform];
 
 		this.argv.$platform = this.argv.platform;
+		this.command.setOptionValue('platform', this.argv.platform);
 
 		// set platform context
 		this.command.platform = {
@@ -947,6 +948,13 @@ export class CLI {
 
 			// if we have a `--platforms` option branch, override the help
 			if (conf.platforms) {
+				// the build command's config `platforms` uses `iphone`, but
+				// the `ti.targetPlatforms` uses `ios`, so rename the key
+				if (!conf.platforms.ios && conf.platforms.iphone) {
+					conf.platforms.ios = conf.platforms.iphone;
+					delete conf.platforms.iphone;
+				}
+
 				this.debugLogger.trace(`Detected conf.platforms loading "${cmdName}", overriding createHelp()`);
 				this.command.createHelp = () => {
 					return Object.assign(new TiHelp(this, conf.platforms), this.command.configureHelp());


### PR DESCRIPTION
When running `ti build` without any args, it would prompt for the platform, but then it wouldn't properly load the platform config because the property was callled `iphone`, yet the prompt value for iOS was `ios` (derived from `ti.targetPlatforms` in `node-titanium-sdk`).

The second problem is the prompted platform value was not being stored back into Commander. The platform prompt happens during the first parse. When calling Commander to re-parse with the new knowledge, it would think `--platform` was not set and then overwrite the previously prompted platform with `undefined` causing platform to be prompted again.