### PR TITLE
fix: Invalid --platform wasn't being validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.1.3 (8/1/2024)
+-------------------
+ * fix: Invalid `--platform` would cause crash because the platform
+   validation was being bypassed
 
 7.1.2 (7/31/2024)
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "titanium",
-	"version": "7.1.2",
+	"version": "7.1.3",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",

--- a/src/cli.js
+++ b/src/cli.js
@@ -656,7 +656,7 @@ export class CLI {
 							.join('\n')
 					}`
 				});
-			} else if (!platformOption.skipValueCheck && !platformOption.values.includes(this.argv.platform)) {
+			} else if (!platformOption.values.includes(this.argv.platform)) {
 				throw new TiError(`Invalid platform "${this.argv.$originalPlatform || this.argv.platform}"`, {
 					code: 'INVALID_PLATFORM'
 				});
@@ -670,7 +670,7 @@ export class CLI {
 				this.logger.banner();
 
 				if (e.code === 'INVALID_PLATFORM') {
-					this.logger.error(e.message);
+					this.logger.error(`${e.message}\n`);
 				}
 
 				this.argv.platform = await prompt({


### PR DESCRIPTION
When running `ti build --platform foo`, the platform validation was being completely skipped and then the CLI would crash trying to get the platform config. As far as I can tell, this bug has been there since 7.0.0.