### PR TITLE
fix: Scan ios hooks from iphone directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.1.4 (8/4/2024)
+-------------------
+ * fix: Load iOS hooks from `iphone` directory in the SDK
+
 7.1.3 (8/1/2024)
 -------------------
  * fix: Invalid `--platform` would cause crash because the platform

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "titanium",
-	"version": "7.1.3",
+	"version": "7.1.4",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",

--- a/src/cli.js
+++ b/src/cli.js
@@ -700,6 +700,9 @@ export class CLI {
 		applyCommandConfig(this, cmdName, this.command, platformConf);
 
 		await this.scanHooks(expand(this.sdk.path, this.argv.platform, 'cli', 'hooks'));
+		if (this.argv.platform === 'ios') {
+			await this.scanHooks(expand(this.sdk.path, 'iphone', 'cli', 'hooks'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
With the recent "fixes" around `--platform`, the platform name `ios` and `iphone` have been normalized to `ios`, but this inadvertently broke the scan hooks since it was checking for `ios` when the directory is called `iphone`. We should rename the directory. :)

Fixes #675 