### PR TITLE
fix: add commands to validKeys

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -149,6 +149,7 @@ export async function run(logger, config, cli) {
 					const subPath = listMatch[1];
 
 					const validKeys = [
+						'commands',
 						'hooks',
 						'modules',
 						'plugins',


### PR DESCRIPTION
Allows me to run `ti config paths.commands --append "test"` to add a path. Currently it errors out with:

```
Titanium Command-Line Interface v9.0.0 SDK v13.4.0.GA
Copyright TiDev, Inc. 4/7/2022-Present. All Rights Reserved.

Please star us on GitHub! https://github.com/tidev/titanium-cli
and https://github.com/tidev/titanium-sdk

Want to help? https://tidev.io/donate or https://tidev.io/contribute

Error: Unsupported key "paths.commands"
```