### PR TITLE
Support async command validate()

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -112,18 +112,23 @@ export class CLI {
 			const { detect } = await import('./util/detect.js');
 			const { data } = await detect(this.debugLogger, ticonfig, this, { nodejs: true, os: true });
 			const { node, npm, os } = data;
+			const info = {
+				os: os.name,
+				platform: process.platform.replace('darwin', 'osx'),
+				osver: os.version,
+				ostype: os.architecture,
+				oscpu: os.numcpus,
+				memory: os.memory,
+				node: node.version,
+				npm: npm.version
+			};
+
+			// deprecated - used by SDK 13.x and older
 			if (typeof callback === 'function') {
-				callback({
-					os: os.name,
-					platform: process.platform.replace('darwin', 'osx'),
-					osver: os.version,
-					ostype: os.architecture,
-					oscpu: os.numcpus,
-					memory: os.memory,
-					node: node.version,
-					npm: npm.version
-				});
+				return callback(info);
 			}
+
+			return info;
 		}
 	};
 
@@ -1627,10 +1632,12 @@ export class CLI {
 		const fn = this.command.module?.validate;
 		if (fn && typeof fn === 'function') {
 			this.debugLogger.trace(`Executing command's validate: ${this.command.name()}`);
-			const result = fn(this.logger || this.debugLogger, this.config, this);
+			let result = fn(this.logger || this.debugLogger, this.config, this);
 
-			// fn should always be a function for `build` and `clean` commands
-			if (typeof result === 'function') {
+			if (result instanceof Promise) {
+				result = await result;
+			} else if (typeof result === 'function') {
+				// fn should always be a function for `build` and `clean` commands
 				await new Promise(resolve => result(resolve));
 			} else if (result === false) {
 				this.command.skipRun = true;


### PR DESCRIPTION
It's time to support `async validate()` in commands. Currently, `validate()` returns a function that gets called with a callback. This was because I didn't have the foresight 15 years ago to make it async until it was too late.

Anyways, the CLI rewrite unlocked async/await and this should have been done a while ago.

Tested:
* Create app project
  * `ti create --sdk 13.4.0.GA`
  * `ti create --sdk 14.0.0` (main)
* Clean app project (both 13.4.0.GA and 14.0.0 apps)
  * `ti clean`
* Build app project (both 13.4.0.GA and 14.0.0 apps)
  * `ti build -p android --build-only`
  * `ti build -p ios --build-only`
* Get app project details (both 13.4.0.GA and 14.0.0)
  * `ti project`
* Create module project
  * `ti create --sdk 13.4.0.GA --type module`
  * `ti create --sdk 14.0.0 --type module` (main)
* Build module project
  * `ti build -p android --sdk 13.4.0.GA`
  * `ti build -p android --sdk 14.0.0`
  * `ti build -p ios --sdk 13.4.0.GA`
  * `ti build -p ios --sdk 14.0.0`