### PR TITLE
Tell titaniumsdk.com to recapture when a release publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,3 +70,26 @@ jobs:
               }
             ]
           }
+
+  # titaniumsdk.com names the current CLI version on its landing page and on
+  # /downloads, and works out the minimum CLI for each SDK release from the same
+  # data. All three are statically generated, so a release changes nothing there
+  # until something tells the site to recapture.
+  #
+  # The dispatch itself lives in titaniumsdk.com, as it does for the seventeen
+  # repositories that notify it about API docs: the event name and the target
+  # are that site's to change, so a rename does not become a pull request here.
+  #
+  # `needs: publish` is load-bearing rather than tidy. The capture reads
+  # `engines.node` from the npm packument, and a release that reached the site
+  # before npm had the tarball would be recorded with a date and a URL but no
+  # Node range - which is exactly what the compatibility page reads.
+  notify-titaniumsdk:
+    name: Notify titaniumsdk.com
+    needs: publish
+    # Skipped in forks: they hold no dispatch token, so this could only ever
+    # produce a failing run.
+    if: github.repository_owner == 'tidev'
+    uses: tidev/titaniumsdk.com/.github/workflows/notify-cli-release.yml@main
+    secrets:
+      dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a `notify-titaniumsdk` job to `publish.yml`, so shipping a CLI updates the
website instead of waiting for someone to remember.

## Why

titaniumsdk.com names the current CLI version on its landing page and on
`/downloads`, and derives the minimum CLI for each SDK release on its
compatibility page from the same captured data. The site is statically
generated and takes no network at build time, so a CLI release changes nothing
there until something tells it to recapture. Today that is a manual
`pnpm registry:cli`.

## How

```yaml
notify-titaniumsdk:
  needs: publish
  if: github.repository_owner == 'tidev'
  uses: tidev/titaniumsdk.com/.github/workflows/notify-cli-release.yml@main
  secrets:
    dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}
```

The dispatch itself lives in titaniumsdk.com, which is how the seventeen
API-doc source repositories already notify it (`notify-api-docs.yml`, called by
`tidev/titanium-sdk` among others). The event name and the target repository are
that site's to change, so a rename there does not become a pull request here.

It carries no payload beyond the release tag, which is used for the commit
message. The capture reads the whole release history from GitHub and every
version from npm on its own.

## Two things worth reviewing

**`needs: publish` is load-bearing, not tidy.** The capture reads
`engines.node` from the npm packument. A release that reached the site before
npm had the tarball would be recorded with a date and a URL but no Node range,
and that range is what the compatibility page reads. Running after the publish
step is what makes the packument current.

**Prereleases dispatch too.** `publish.yml` already publishes them under the
`next` tag. The site records prereleases in its registry but never advertises
one as the current version, so this is correct and needs no condition.

## Before this can merge

- The receiving side is [titaniumsdk.com#55](https://github.com/tidev/titaniumsdk.com/pull/55),
  which adds `notify-cli-release.yml` and `refresh-cli-releases.yml`. **That has
  to land on `main` first** - this job references it at `@main` and will fail to
  resolve until then.
- `REGEN_DOCS_GITHUB_TOKEN` must be visible to this repository. It is the same
  org secret `tidev/titanium-sdk` uses for its notify job; I could not verify
  its repository scope without org admin. If it is not in scope, this job fails
  loudly on a 401 rather than going quietly green.

Validated with `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)